### PR TITLE
fix: Add author & description to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "version": "0.0.0",
+  "description": "Matterbridge Home Assistant plugin",
+  "author": "https://github.com/t0bst4r",
   "type": "module",
   "types": "lib/index.d.ts",
   "publishConfig": {


### PR DESCRIPTION
## Proposed Changes

The main matterbridge UI page has been coming up blank for me with 1.3.10+ with this error in the console:

```
Uncaught TypeError: Cannot read properties of undefined (reading 'replace')
    at Home.js:253:40
    at Array.map (<anonymous>)
    at cx (Home.js:246:26)
    at ki (react-dom.production.min.js:167:137)
    at _s (react-dom.production.min.js:197:258)
    at kl (react-dom.production.min.js:292:88)
    at xc (react-dom.production.min.js:280:389)
    at yc (react-dom.production.min.js:280:320)
    at vc (react-dom.production.min.js:280:180)
    at ic (react-dom.production.min.js:271:88)
```

Home.js line 253 is `<td>{plugin.author.replace('https://github.com/', '')}</td>`

This adds the `author` & `description` fields so the page renders again.
