### PR TITLE
fix(sensor): add NaN check to temperature and humidity sensors

### DIFF
--- a/packages/home-assistant-matter-hub/core/src/aspects/humidity-measurement-aspect.ts
+++ b/packages/home-assistant-matter-hub/core/src/aspects/humidity-measurement-aspect.ts
@@ -35,7 +35,7 @@ export class HumidityMeasurementAspect extends AspectBase {
   }
 
   getMeasuredValue(state: string) {
-    if (state != null) {
+    if (state != null && !isNaN(+state)) {
       return +state * 100;
     }
     return null;

--- a/packages/home-assistant-matter-hub/core/src/aspects/temperature-measurement-aspect.ts
+++ b/packages/home-assistant-matter-hub/core/src/aspects/temperature-measurement-aspect.ts
@@ -37,7 +37,7 @@ export class TemperatureMeasurementAspect extends AspectBase {
   }
 
   getTemperatureInCelsius(entity: HomeAssistantMatterEntity): number | null {
-    if (entity.state == null) {
+    if (entity.state == null || isNaN(+entity.state)) {
       return null;
     }
 


### PR DESCRIPTION
## Proposed Changes

> Add a NaN check to the temperature and humidity sensors because they report NaN% or NaN C when unavailable

## Related Issues

> Related issues or pull requests
